### PR TITLE
Replace Remixer.remixerItemList with a context-based HashMap.

### DIFF
--- a/remixer_core/src/main/java/com/google/android/libraries/remixer/Remixer.java
+++ b/remixer_core/src/main/java/com/google/android/libraries/remixer/Remixer.java
@@ -64,7 +64,7 @@ public class Remixer {
    * This adds a remixer item ({@link Variable} or {@link Trigger}) to be tracked and displayed.
    * Checks that the remixer item is compatible with the existing remixer items with the same key.
    *
-   * <p>This method also removes old remixer items whose contexts have been reclaimed by the Garbage
+   * <p>This method also removes old remixer items whose contexts have been reclaimed by the garbage
    * collector which are being replaced by items from the same class of context. No items are
    * removed until equivalent ones from the same context class are added to replace them. This
    * guarantees that no incompatible items for the same key are ever accepted.
@@ -103,8 +103,8 @@ public class Remixer {
     }
     for (RemixerItem remove : itemsToRemove) {
       listForKey.remove(remove);
-      // no need to remove from contextMap since that will be cleared just by the context being
-      // reclaimed, that's why it's a WeakHashMap.
+      // no need to remove from contextMap, contextMap has already removed the whole list of items
+      // with that context that was reclaimed, see cleanUpCallbacks().
     }
     if (remixerItem instanceof Variable && listForKey.size() > 0) {
       // Make sure that variables use their current value if it has been modified in another

--- a/remixer_core/src/main/java/com/google/android/libraries/remixer/Remixer.java
+++ b/remixer_core/src/main/java/com/google/android/libraries/remixer/Remixer.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.WeakHashMap;
 
 /**
  * Contains a list of {@link Variable}es.
@@ -35,10 +36,11 @@ public class Remixer {
    * different activities and the value has to be shared across those.
    */
   private HashMap<String, List<RemixerItem>> keyMap;
+
   /**
-   * A list of all the Remixer Items added to the Remixer.
+   * This is a map of contexts to a list of remixer items for the given context.
    */
-  private List<RemixerItem> remixerItems;
+  private WeakHashMap<Object, List<RemixerItem>> contextMap;
 
   /**
    * Gets the singleton for Remixer.
@@ -55,21 +57,21 @@ public class Remixer {
 
   Remixer() {
     keyMap = new HashMap<>();
-    remixerItems = new ArrayList<>();
+    contextMap = new WeakHashMap<>();
   }
 
   /**
    * This adds a remixer item ({@link Variable} or {@link Trigger}) to be tracked and displayed.
    * Checks that the remixer item is compatible with the existing remixer items with the same key.
    *
-   * <p>This method also removes old remixer items whose contexts have been reclaimed by the
-   * Garbage collector which are being replaced by items from the same class of context.
-   * No items are removed until equivalent ones from the same context class are added to
-   * replace them. This guarantees that no incompatible items for the same key are ever accepted.
+   * <p>This method also removes old remixer items whose contexts have been reclaimed by the Garbage
+   * collector which are being replaced by items from the same class of context. No items are
+   * removed until equivalent ones from the same context class are added to replace them. This
+   * guarantees that no incompatible items for the same key are ever accepted.
    *
    * @param remixerItem The remixer item to be added.
    * @throws IncompatibleRemixerItemsWithSameKeyException Other items with the same key have been
-   *     added other contexts with incompatible types.
+   * added other contexts with incompatible types.
    * @throws DuplicateKeyException Another item with the same key was added for the same context.
    */
   @SuppressWarnings("unchecked")
@@ -101,7 +103,8 @@ public class Remixer {
     }
     for (RemixerItem remove : itemsToRemove) {
       listForKey.remove(remove);
-      remixerItems.remove(remove);
+      // no need to remove from contextMap since that will be cleared just by the context being
+      // reclaimed, that's why it's a WeakHashMap.
     }
     if (remixerItem instanceof Variable && listForKey.size() > 0) {
       // Make sure that variables use their current value if it has been modified in another
@@ -117,7 +120,7 @@ public class Remixer {
     }
     listForKey.add(remixerItem);
     remixerItem.setRemixer(this);
-    remixerItems.add(remixerItem);
+    getRemixerItemsForContext(remixerItem.getContext()).add(remixerItem);
   }
 
   List<RemixerItem> getItemsWithKey(String key) {
@@ -131,33 +134,31 @@ public class Remixer {
     return list;
   }
 
-  public List<RemixerItem> getRemixerItems() {
-    return remixerItems;
-  }
-
   /**
    * Gets all the Remixer Items associated with {@code context}. {@code context} is expected to be
    * an Activity, it is Object here because remixer_core cannot depend on the Android SDK.
    */
   public List<RemixerItem> getRemixerItemsForContext(Object context) {
-    List<RemixerItem> result = new ArrayList<>();
-    for (RemixerItem item : remixerItems) {
-      if (item.matchesContext(context)) {
-        result.add(item);
-      }
+    List<RemixerItem> list = null;
+    if (contextMap.containsKey(context)) {
+      list = contextMap.get(context);
+    } else {
+      list = new ArrayList<>();
+      contextMap.put(context, list);
     }
-    return result;
+    return list;
   }
 
   /**
-   * Removes callbacks for all remixes whose context is {@code activity}. This makes sure
-   * {@code activity} doesn't leak through its callbacks.
+   * Removes callbacks for all remixes whose context is {@code activity}. This makes sure {@code
+   * activity} doesn't leak through its callbacks.
    */
   public void cleanUpCallbacks(Object activity) {
-    for (RemixerItem remixerItem : remixerItems) {
-      if (remixerItem.matchesContext(activity)) {
-        remixerItem.clearCallback();
-      }
+    for (RemixerItem remixerItem : contextMap.get(activity)) {
+      remixerItem.clearCallback();
+      remixerItem.clearContext();
     }
+    contextMap.remove(activity);
   }
 }
+

--- a/remixer_core/src/main/java/com/google/android/libraries/remixer/Remixer.java
+++ b/remixer_core/src/main/java/com/google/android/libraries/remixer/Remixer.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.WeakHashMap;
 
 /**
  * Contains a list of {@link Variable}es.
@@ -40,7 +39,7 @@ public class Remixer {
   /**
    * This is a map of contexts to a list of remixer items for the given context.
    */
-  private WeakHashMap<Object, List<RemixerItem>> contextMap;
+  private HashMap<Object, List<RemixerItem>> contextMap;
 
   /**
    * Gets the singleton for Remixer.
@@ -57,7 +56,7 @@ public class Remixer {
 
   Remixer() {
     keyMap = new HashMap<>();
-    contextMap = new WeakHashMap<>();
+    contextMap = new HashMap<>();
   }
 
   /**
@@ -69,9 +68,10 @@ public class Remixer {
    * removed until equivalent ones from the same context class are added to replace them. This
    * guarantees that no incompatible items for the same key are ever accepted.
    *
-   * @param remixerItem The remixer item to be added.
+   * @param remixerItem The remixer item to be added. It must have a context object otherwise it
+   *     will never be displayed, and thus not be editable.
    * @throws IncompatibleRemixerItemsWithSameKeyException Other items with the same key have been
-   * added other contexts with incompatible types.
+   *     added other contexts with incompatible types.
    * @throws DuplicateKeyException Another item with the same key was added for the same context.
    */
   @SuppressWarnings("unchecked")

--- a/remixer_core/src/test/java/com/google/android/libraries/remixer/RemixerTest.java
+++ b/remixer_core/src/test/java/com/google/android/libraries/remixer/RemixerTest.java
@@ -114,14 +114,15 @@ public class RemixerTest {
     // Add the first.
     remixer.addItem(variableString);
     // Simulate the first context is reclaimed.
-    variableString.clearContext();
-    variableString.clearCallback();
+    remixer.cleanUpCallbacks(context1);
     // Add the second, since the first object was "reclaimed" and they are compatible, the first
     // should be removed, and the second should be kept.
     remixer.addItem(variableString2);
-    List<RemixerItem> list = remixer.getRemixerItems();
-    Assert.assertEquals(1, list.size());
-    Assert.assertEquals(variable2, list.get(0));
+    List<RemixerItem> list1 = remixer.getRemixerItemsForContext(context1);
+    List<RemixerItem> list2 = remixer.getRemixerItemsForContext(context2);
+    Assert.assertEquals(0, list1.size());
+    Assert.assertEquals(1, list2.size());
+    Assert.assertEquals(variable2, list2.get(0));
   }
 
   @Test
@@ -156,7 +157,7 @@ public class RemixerTest {
   public void remixerReturnsListInOrder() {
     remixer.addItem(variable);
     remixer.addItem(variable2);
-    List<RemixerItem> remixerItemList = remixer.getRemixerItems();
+    List<RemixerItem> remixerItemList = remixer.getRemixerItemsForContext(this);
     Assert.assertEquals(variable, remixerItemList.get(0));
     Assert.assertEquals(variable2, remixerItemList.get(1));
   }


### PR DESCRIPTION
Currently there is no need for a flat data structure that contains all RemixerItems, instead, all operations look at either RemixerItems by key or by context. Particularly the operations that look at RemixerItems by contexts are really slow since they have to iterate by all remixes.