### PR TITLE
Adds a constraint field to serialization.

### DIFF
--- a/remixer_core/src/main/java/com/google/android/libraries/remixer/ItemListVariable.java
+++ b/remixer_core/src/main/java/com/google/android/libraries/remixer/ItemListVariable.java
@@ -26,6 +26,11 @@ import java.util.List;
  */
 public class ItemListVariable<T> extends Variable<T> {
 
+  /**
+   * The serializable string to represent the constraints on values for variables of this class.
+   */
+  public final static String SERIALIZABLE_CONSTRAINTS = ";ost";
+
   private final List<T> valueList;
 
   /**
@@ -64,6 +69,13 @@ public class ItemListVariable<T> extends Variable<T> {
 
   public List<T> getValueList() {
     return valueList;
+  }
+
+  /**
+   * Gets the serializable constraints string for this variable.
+   */
+  public String getSerializableConstraints() {
+    return SERIALIZABLE_CONSTRAINTS;
   }
 
   /**

--- a/remixer_core/src/main/java/com/google/android/libraries/remixer/ItemListVariable.java
+++ b/remixer_core/src/main/java/com/google/android/libraries/remixer/ItemListVariable.java
@@ -29,7 +29,7 @@ public class ItemListVariable<T> extends Variable<T> {
   /**
    * The serializable string to represent the constraints on values for variables of this class.
    */
-  public final static String SERIALIZABLE_CONSTRAINTS = ";ost";
+  public final static String SERIALIZABLE_CONSTRAINTS = "list";
 
   private final List<T> valueList;
 

--- a/remixer_core/src/main/java/com/google/android/libraries/remixer/ItemListVariable.java
+++ b/remixer_core/src/main/java/com/google/android/libraries/remixer/ItemListVariable.java
@@ -16,6 +16,7 @@
 
 package com.google.android.libraries.remixer;
 
+import com.google.android.libraries.remixer.serialization.StoredVariable;
 import java.util.Arrays;
 import java.util.List;
 
@@ -25,11 +26,6 @@ import java.util.List;
  * <p><b>This class is not thread-safe and should only be used from the main thread.</b>
  */
 public class ItemListVariable<T> extends Variable<T> {
-
-  /**
-   * The serializable string to represent the constraints on values for variables of this class.
-   */
-  public final static String SERIALIZABLE_CONSTRAINTS = "list";
 
   private final List<T> valueList;
 
@@ -75,7 +71,7 @@ public class ItemListVariable<T> extends Variable<T> {
    * Gets the serializable constraints string for this variable.
    */
   public String getSerializableConstraints() {
-    return SERIALIZABLE_CONSTRAINTS;
+    return StoredVariable.ITEM_LIST_VARIABLE_CONSTRAINT;
   }
 
   /**

--- a/remixer_core/src/main/java/com/google/android/libraries/remixer/RangeVariable.java
+++ b/remixer_core/src/main/java/com/google/android/libraries/remixer/RangeVariable.java
@@ -27,6 +27,12 @@ import java.util.Locale;
  */
 public class RangeVariable extends Variable<Float> {
 
+  /**
+   * The serializable string to represent the constraints on values for variables of this class.
+   */
+  public final static String SERIALIZABLE_CONSTRAINTS = "range";
+
+
   private static final String INVALID_RANGE_ERROR_FORMAT =
       "Invalid range for Variable %s min: %d, max: %d";
   private static final String NEGATIVE_STEPPING_ERROR_FORMAT =
@@ -141,6 +147,13 @@ public class RangeVariable extends Variable<Float> {
 
   public float getIncrement() {
     return increment;
+  }
+
+  /**
+   * Gets the serializable constraints string for this variable.
+   */
+  public String getSerializableConstraints() {
+    return SERIALIZABLE_CONSTRAINTS;
   }
 
   /**

--- a/remixer_core/src/main/java/com/google/android/libraries/remixer/RangeVariable.java
+++ b/remixer_core/src/main/java/com/google/android/libraries/remixer/RangeVariable.java
@@ -16,6 +16,7 @@
 
 package com.google.android.libraries.remixer;
 
+import com.google.android.libraries.remixer.serialization.StoredVariable;
 import java.util.Locale;
 
 /**
@@ -26,12 +27,6 @@ import java.util.Locale;
  * <p><b>This class is not thread-safe and should only be used from the main thread.</b>
  */
 public class RangeVariable extends Variable<Float> {
-
-  /**
-   * The serializable string to represent the constraints on values for variables of this class.
-   */
-  public final static String SERIALIZABLE_CONSTRAINTS = "range";
-
 
   private static final String INVALID_RANGE_ERROR_FORMAT =
       "Invalid range for Variable %s min: %d, max: %d";
@@ -153,7 +148,7 @@ public class RangeVariable extends Variable<Float> {
    * Gets the serializable constraints string for this variable.
    */
   public String getSerializableConstraints() {
-    return SERIALIZABLE_CONSTRAINTS;
+    return StoredVariable.RANGE_VARIABLE_CONSTRAINT;
   }
 
   /**

--- a/remixer_core/src/main/java/com/google/android/libraries/remixer/Variable.java
+++ b/remixer_core/src/main/java/com/google/android/libraries/remixer/Variable.java
@@ -27,6 +27,11 @@ import java.lang.ref.WeakReference;
 public class Variable<T> {
 
   /**
+   * The serializable string to represent the constraints on values for variables of this class.
+   */
+  public final static String SERIALIZABLE_CONSTRAINTS = "none";
+
+  /**
    * The name to display in the UI for this variable.
    */
   private final String title;
@@ -182,6 +187,13 @@ public class Variable<T> {
     checkValue(newValue);
     selectedValue = newValue;
     runCallback();
+  }
+
+  /**
+   * Gets the serializable constraints string for this variable.
+   */
+  public String getSerializableConstraints() {
+    return SERIALIZABLE_CONSTRAINTS;
   }
 
   /**

--- a/remixer_core/src/main/java/com/google/android/libraries/remixer/Variable.java
+++ b/remixer_core/src/main/java/com/google/android/libraries/remixer/Variable.java
@@ -16,6 +16,7 @@
 
 package com.google.android.libraries.remixer;
 
+import com.google.android.libraries.remixer.serialization.StoredVariable;
 import java.lang.ref.WeakReference;
 
 /**
@@ -25,11 +26,6 @@ import java.lang.ref.WeakReference;
  * <p><b>This class is not thread-safe and should only be used from the main thread.</b>
  */
 public class Variable<T> {
-
-  /**
-   * The serializable string to represent the constraints on values for variables of this class.
-   */
-  public final static String SERIALIZABLE_CONSTRAINTS = "none";
 
   /**
    * The name to display in the UI for this variable.
@@ -193,7 +189,7 @@ public class Variable<T> {
    * Gets the serializable constraints string for this variable.
    */
   public String getSerializableConstraints() {
-    return SERIALIZABLE_CONSTRAINTS;
+    return StoredVariable.VARIABLE_CONSTRAINT;
   }
 
   /**

--- a/remixer_core/src/main/java/com/google/android/libraries/remixer/serialization/StoredVariable.java
+++ b/remixer_core/src/main/java/com/google/android/libraries/remixer/serialization/StoredVariable.java
@@ -34,6 +34,24 @@ import java.util.List;
  */
 public class StoredVariable<T> {
 
+  /**
+   * The serializable string to represent the constraints on values for variables of the
+   * {@link Variable} class.
+   */
+  public final static String VARIABLE_CONSTRAINT = "none";
+
+  /**
+   * The serializable string to represent the constraints on values for variables of the
+   * {@link ItemListVariable} class.
+   */
+  public final static String ITEM_LIST_VARIABLE_CONSTRAINT = "list";
+
+  /**
+   * The serializable string to represent the constraints on values for variables of the
+   * {@link RangeVariable} class.
+   */
+  public final static String RANGE_VARIABLE_CONSTRAINT = "range";
+
   // Json dictionary keys to serialize this object
   static final String KEY = "key";
   static final String TITLE = "title";

--- a/remixer_core/src/main/java/com/google/android/libraries/remixer/serialization/StoredVariable.java
+++ b/remixer_core/src/main/java/com/google/android/libraries/remixer/serialization/StoredVariable.java
@@ -17,8 +17,11 @@
 package com.google.android.libraries.remixer.serialization;
 
 import com.google.android.libraries.remixer.DataType;
+import com.google.android.libraries.remixer.ItemListVariable;
+import com.google.android.libraries.remixer.RangeVariable;
 import com.google.android.libraries.remixer.Remixer;
 import com.google.android.libraries.remixer.Variable;
+
 import java.util.List;
 
 /**
@@ -34,6 +37,7 @@ public class StoredVariable<T> {
   // Json dictionary keys to serialize this object
   static final String KEY = "key";
   static final String TITLE = "title";
+  static final String CONSTRAINTS = "constraints";
   static final String DATA_TYPE = "dataType";
   static final String SELECTED_VALUE = "selectedValue";
   static final String POSSIBLE_VALUES = "possibleValues";
@@ -54,6 +58,13 @@ public class StoredVariable<T> {
    * DataType}.
    */
   String dataType;
+  /**
+   * The constraints on this variable.
+   *
+   * <p>If this is a regular {@link Variable} it's "none", if it's an {@link ItemListVariable} it's
+   * "list", and if it is a {@link RangeVariable} it's "range".
+   */
+  String constraints;
 
   /**
    * The currently selected value for the variable.
@@ -94,6 +105,14 @@ public class StoredVariable<T> {
 
   public void setTitle(String title) {
     this.title = title;
+  }
+
+  public String getConstraints() {
+    return constraints;
+  }
+
+  public void setConstraints(String constraints) {
+    this.constraints = constraints;
   }
 
   public String getDataType() {
@@ -225,6 +244,7 @@ public class StoredVariable<T> {
     }
     storedVariable.key = item.getKey();
     storedVariable.title = item.getTitle();
+    storedVariable.constraints = item.getSerializableConstraints();
     return storedVariable;
   }
 }

--- a/remixer_core/src/main/java/com/google/android/libraries/remixer/serialization/ValueConverter.java
+++ b/remixer_core/src/main/java/com/google/android/libraries/remixer/serialization/ValueConverter.java
@@ -17,7 +17,6 @@
 package com.google.android.libraries.remixer.serialization;
 
 import com.google.android.libraries.remixer.ItemListVariable;
-import com.google.android.libraries.remixer.RangeVariable;
 import com.google.android.libraries.remixer.Variable;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -74,9 +73,9 @@ public abstract class ValueConverter<T> {
     result.selectedValue = parseValue(object.get(StoredVariable.SELECTED_VALUE));
     result.constraints = object.get(StoredVariable.CONSTRAINTS).getAsString();
 
-    if (ItemListVariable.SERIALIZABLE_CONSTRAINTS.equals(result.constraints)) {
+    if (StoredVariable.ITEM_LIST_VARIABLE_CONSTRAINT.equals(result.constraints)) {
       deserializePossibleValues(result, object.get(StoredVariable.POSSIBLE_VALUES));
-    } else if (RangeVariable.SERIALIZABLE_CONSTRAINTS.equals(result.constraints)) {
+    } else if (StoredVariable.RANGE_VARIABLE_CONSTRAINT.equals(result.constraints)) {
       deserializeRangeProperties(result, object);
     }
     result.dataType = dataType;
@@ -111,14 +110,14 @@ public abstract class ValueConverter<T> {
     object.add(StoredVariable.DATA_TYPE, new JsonPrimitive(src.dataType));
     object.add(StoredVariable.SELECTED_VALUE, valueToJson(src.selectedValue));
     object.add(StoredVariable.CONSTRAINTS, new JsonPrimitive(src.constraints));
-    if (ItemListVariable.SERIALIZABLE_CONSTRAINTS.equals(src.constraints)) {
+    if (StoredVariable.ITEM_LIST_VARIABLE_CONSTRAINT.equals(src.constraints)) {
       JsonArray possibleValues = new JsonArray();
       for (T item : src.possibleValues) {
         possibleValues.add(valueToJson(item));
       }
       object.add(StoredVariable.POSSIBLE_VALUES, possibleValues);
     }
-    if (RangeVariable.SERIALIZABLE_CONSTRAINTS.equals(src.constraints)) {
+    if (StoredVariable.RANGE_VARIABLE_CONSTRAINT.equals(src.constraints)) {
       object.add(StoredVariable.MIN_VALUE, valueToJson(src.minValue));
       object.add(StoredVariable.MAX_VALUE, valueToJson(src.maxValue));
       object.add(StoredVariable.INCREMENT, valueToJson(src.increment));

--- a/remixer_core/src/main/java/com/google/android/libraries/remixer/serialization/ValueConverter.java
+++ b/remixer_core/src/main/java/com/google/android/libraries/remixer/serialization/ValueConverter.java
@@ -16,6 +16,8 @@
 
 package com.google.android.libraries.remixer.serialization;
 
+import com.google.android.libraries.remixer.ItemListVariable;
+import com.google.android.libraries.remixer.RangeVariable;
 import com.google.android.libraries.remixer.Variable;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -69,27 +71,34 @@ public abstract class ValueConverter<T> {
   public StoredVariable<T> deserialize(JsonElement json) {
     StoredVariable<T> result = new StoredVariable<>();
     JsonObject object = json.getAsJsonObject();
-    if (object.has(StoredVariable.SELECTED_VALUE)) {
-      result.selectedValue = parseValue(object.get(StoredVariable.SELECTED_VALUE));
+    result.selectedValue = parseValue(object.get(StoredVariable.SELECTED_VALUE));
+    result.constraints = object.get(StoredVariable.CONSTRAINTS).getAsString();
+
+    if (ItemListVariable.SERIALIZABLE_CONSTRAINTS.equals(result.constraints)) {
+      deserializePossibleValues(result, object.get(StoredVariable.POSSIBLE_VALUES));
+    } else if (RangeVariable.SERIALIZABLE_CONSTRAINTS.equals(result.constraints)) {
+      deserializeRangeProperties(result, object);
     }
-    JsonElement possibleValuesElement = object.get(StoredVariable.POSSIBLE_VALUES);
+    result.dataType = dataType;
+    result.key = object.getAsJsonPrimitive(StoredVariable.KEY).getAsString();
+    result.title = object.getAsJsonPrimitive(StoredVariable.TITLE).getAsString();
+    return result;
+  }
+
+  private void deserializeRangeProperties(StoredVariable<T> result, JsonObject object) {
+    result.minValue = parseValue(object.getAsJsonPrimitive(StoredVariable.MIN_VALUE));
+    result.maxValue = parseValue(object.getAsJsonPrimitive(StoredVariable.MAX_VALUE));
+    result.increment = parseValue(object.getAsJsonPrimitive(StoredVariable.INCREMENT));
+  }
+
+  private void deserializePossibleValues(StoredVariable<T> result, JsonElement possibleValuesElement) {
     if (possibleValuesElement != null) {
       JsonArray array = possibleValuesElement.getAsJsonArray();
       result.possibleValues = new ArrayList<>();
       for (JsonElement arrayElement : array) {
         result.possibleValues.add(parseValue(arrayElement));
       }
-    } else if (object.has(StoredVariable.MIN_VALUE) && object.has(StoredVariable.MAX_VALUE)
-        && object.has(StoredVariable.INCREMENT)) {
-      // we have a complete RangeVariable here, let's export it.
-      result.minValue = parseValue(object.getAsJsonPrimitive(StoredVariable.MIN_VALUE));
-      result.maxValue = parseValue(object.getAsJsonPrimitive(StoredVariable.MAX_VALUE));
-      result.increment = parseValue(object.getAsJsonPrimitive(StoredVariable.INCREMENT));
     }
-    result.dataType = dataType;
-    result.key = object.getAsJsonPrimitive(StoredVariable.KEY).getAsString();
-    result.title = object.getAsJsonPrimitive(StoredVariable.TITLE).getAsString();
-    return result;
   }
 
   /**
@@ -100,18 +109,16 @@ public abstract class ValueConverter<T> {
     object.add(StoredVariable.KEY, new JsonPrimitive(src.key));
     object.add(StoredVariable.TITLE, new JsonPrimitive(src.title));
     object.add(StoredVariable.DATA_TYPE, new JsonPrimitive(src.dataType));
-    if (src.selectedValue != null) {
-      object.add(StoredVariable.SELECTED_VALUE, valueToJson(src.selectedValue));
-    }
-    if (src.possibleValues != null && src.possibleValues.size() > 0) {
+    object.add(StoredVariable.SELECTED_VALUE, valueToJson(src.selectedValue));
+    object.add(StoredVariable.CONSTRAINTS, new JsonPrimitive(src.constraints));
+    if (ItemListVariable.SERIALIZABLE_CONSTRAINTS.equals(src.constraints)) {
       JsonArray possibleValues = new JsonArray();
       for (T item : src.possibleValues) {
         possibleValues.add(valueToJson(item));
       }
       object.add(StoredVariable.POSSIBLE_VALUES, possibleValues);
     }
-    if (src.minValue != null && src.maxValue != null && src.increment != null) {
-      // We have a complete RangeVariable here. let's export it.
+    if (RangeVariable.SERIALIZABLE_CONSTRAINTS.equals(src.constraints)) {
       object.add(StoredVariable.MIN_VALUE, valueToJson(src.minValue));
       object.add(StoredVariable.MAX_VALUE, valueToJson(src.maxValue));
       object.add(StoredVariable.INCREMENT, valueToJson(src.increment));

--- a/remixer_core/src/test/java/com/google/android/libraries/remixer/serialization/CompareHelper.java
+++ b/remixer_core/src/test/java/com/google/android/libraries/remixer/serialization/CompareHelper.java
@@ -55,5 +55,6 @@ public class CompareHelper {
   private static void assertConsistent(StoredVariable storage, Variable item) {
     Assert.assertEquals(item.getKey(), storage.key);
     Assert.assertEquals(item.getTitle(), storage.title);
+    Assert.assertEquals(item.getSerializableConstraints(), storage.constraints);
   }
 }


### PR DESCRIPTION
A constraint field represents, in a platform-agnostic way, what kind of variable is serialized (regular, item list or range), and makes the logic to de-/serialize easier to read and understand.

This is a xplat decision to make serialization less error-prone.