### PR TITLE
Make sure remixer interacts well with Proguard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: android
 jdk: oraclejdk8
 
 env:
-  - ANDROID_TARGET=25
-  - BUILD_TOOLS=25.0.0
+  - ANDROID_TARGET=25 BUILD_TOOLS=25.0.0
 
 android:
   components:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: android
 jdk: oraclejdk8
 
 env:
-  matrix:
-    - ANDROID_TARGET=android-25
+  - ANDROID_TARGET=25
+  - BUILD_TOOLS=25.0.0
 
 android:
   components:
@@ -13,13 +13,13 @@ android:
     # See https://github.com/travis-ci/travis-ci/issues/6040#issuecomment-219367943 for more
     # details.
     - platform-tools #latest
-    - build-tools-25.0.0
-    - android-25
+    - "build-tools-$BUILD_TOOLS"
+    - "android-$ANDROID_TARGET"
     - extra-android-support
     - extra-android-m2repository
     - extra-google-google_play_services
     - extra-google-m2repository
-    - addon-google_apis-google-25
+    - "addon-google_apis-google-$ANDROID_TARGET"
 
 
 before_install:
@@ -27,18 +27,20 @@ before_install:
 
 licenses:
   - 'android-sdk-license-.+'
-  - 'google-gdk-license-.+'
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
 cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
 script:
-  - ./gradlew check jacocoTestReport
+  - ./gradlew lint check jacocoTestReport
+  # building remixer_example:assembleRelease will fail explicitly if proguarding is broken.
+  - ./gradlew remixer_example:assembleRelease
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@ And in your modules, apply the `android-apt` plugin and add the remixer dependen
 apply plugin: 'android-apt'
 
 dependencies {
-    compile 'com.github.material-foundation.material-remixer-android:remixer:0.6.5'
+    compile 'com.github.material-foundation.material-remixer-android:remixer_core:0.6.5'
+    compile 'com.github.material-foundation.material-remixer-android:remixer_ui:0.6.5'
+    compile 'com.github.material-foundation.material-remixer-android:remixer_storage:0.6.5'
+    provided 'com.github.material-foundation.material-remixer-android:remixer_annotation:0.6.5'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,8 @@ task clean(type: Delete) {
 }
 
 ext {
+  // Force release proguard when running on a Continuous Integration environment (like TravisCI).
+  forceReleaseProguard = System.getenv("CI").equals("true");
   // Sdk and tools
   minSdkVersion = 15
   targetSdkVersion = 25

--- a/remixer/build.gradle
+++ b/remixer/build.gradle
@@ -19,6 +19,11 @@ apply plugin: 'com.github.dcendents.android-maven'
 
 group = 'com.github.material-foundation'
 
+/* While this library is no longer used directly (since it makes proguard fail), we keep it mostly
+ * for javadoc aggregation (:allJavadoc and :javadocJar). This allows jitpack to automatically
+ * generate aggregated javadoc.
+ */
+
 android {
   compileSdkVersion rootProject.ext.compileSdkVersion
   buildToolsVersion rootProject.ext.buildToolsVersion

--- a/remixer_example/build.gradle
+++ b/remixer_example/build.gradle
@@ -31,7 +31,7 @@ android {
 
   buildTypes {
     release {
-      minifyEnabled false
+      minifyEnabled rootProject.ext.forceReleaseProguard
       proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
   }
@@ -51,6 +51,12 @@ android {
 dependencies {
   compile "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
   compile project(':remixer')
+  /*
+  compile project(':remixer_ui')
+  compile project(':remixer_core')
+  compile project(':remixer_storage')
+  provided project(':remixer_annotation')
+  */
 }
 
 // Depend on gms google services for Firebase Support, keep at the bottom.

--- a/remixer_example/build.gradle
+++ b/remixer_example/build.gradle
@@ -50,13 +50,10 @@ android {
 
 dependencies {
   compile "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
-  compile project(':remixer')
-  /*
   compile project(':remixer_ui')
   compile project(':remixer_core')
   compile project(':remixer_storage')
   provided project(':remixer_annotation')
-  */
 }
 
 // Depend on gms google services for Firebase Support, keep at the bottom.


### PR DESCRIPTION
Proguard has been disabled on Remixer for a while to iterate quickly. For that reason I did not notice when we broke proguarding projects that depend on Remixer.

We created a `remixer` empty gradle subproject that depends on all other projects as compile dependencies and made it easier for clients to have a single dependency to depend on instead of 3 of type `compile` and one of type `provides`.

The problem with `compile` dependencies is that the classes in remixer_annotation are added to the classpath. Those classes depend on the annotation processing classes (javax.model.*, javax.annotation.processing.* ...) in the JDK which are unavailable in the Android SDK, so when proguard runs it cannot resolve those classes and fails.

A lot of those errors are visible on a TravisCI run explicitly designed to make it fail: https://travis-ci.org/material-foundation/material-remixer-android/builds/200502951, the final version of this PR fixes the root causes of the failures.