### PR TITLE
Fixed TextWatcher being called when binding new value to old view

### DIFF
--- a/remixer_ui/src/main/java/com/google/android/libraries/remixer/ui/widget/StringVariableWidget.java
+++ b/remixer_ui/src/main/java/com/google/android/libraries/remixer/ui/widget/StringVariableWidget.java
@@ -37,6 +37,7 @@ public class StringVariableWidget extends RelativeLayout
 
   private TextView nameText;
   private EditText text;
+  private Variable<String> boundVariable;
 
   public StringVariableWidget(Context context) {
     super(context);
@@ -55,12 +56,6 @@ public class StringVariableWidget extends RelativeLayout
     super.onFinishInflate();
     text = (EditText) findViewById(R.id.stringVariableText);
     nameText = (TextView) findViewById(R.id.variableName);
-  }
-
-  @Override
-  public void bindVariable(@NonNull final Variable<String> variable) {
-    nameText.setText(variable.getTitle());
-    text.setText(variable.getSelectedValue());
     text.addTextChangedListener(new TextWatcher() {
 
       @Override
@@ -73,8 +68,15 @@ public class StringVariableWidget extends RelativeLayout
 
       @Override
       public void afterTextChanged(Editable s) {
-        variable.setValue(s.toString());
+        boundVariable.setValue(s.toString());
       }
     });
+  }
+
+  @Override
+  public void bindVariable(@NonNull final Variable<String> variable) {
+    boundVariable = variable;
+    nameText.setText(variable.getTitle());
+    text.setText(variable.getSelectedValue());
   }
 }

--- a/remixer_ui/src/test/java/com/google/android/libraries/remixer/ui/widget/StringVariableWidgetTest.java
+++ b/remixer_ui/src/test/java/com/google/android/libraries/remixer/ui/widget/StringVariableWidgetTest.java
@@ -79,10 +79,10 @@ public class StringVariableWidgetTest {
 
   @Test
   public void callbackIsCalled() {
-    // Check that the callback  was called. This should've happened during setUp()
-    verify(mockCallback, times(1)).onValueSet(variable);
+    // Check that the callback  was called. This should've happened during setUp() twice
+    verify(mockCallback, times(2)).onValueSet(variable);
     text.setText("green");
     // After changing the text, check that the callback was called once again
-    verify(mockCallback, times(2)).onValueSet(variable);
+    verify(mockCallback, times(3)).onValueSet(variable);
   }
 }


### PR DESCRIPTION
Apparently the change also resulted with an additional callback invocation during initialization, because the listener is already present when the `setText` is called from the initial call to `bindValue`.